### PR TITLE
Add/Update walk helpers and their uses

### DIFF
--- a/backends/r1cs/lib/r1cs/Transforms/R1CSLoweringPass.cpp
+++ b/backends/r1cs/lib/r1cs/Transforms/R1CSLoweringPass.cpp
@@ -24,6 +24,7 @@
 #include "llzk/Transforms/LLZKLoweringUtils.h"
 #include "llzk/Util/Constants.h"
 #include "llzk/Util/DynamicAPIntHelper.h"
+#include "llzk/Util/Walk.h"
 
 #include <mlir/IR/BuiltinOps.h>
 
@@ -582,9 +583,9 @@ class PassImpl : public r1cs::impl::R1CSLoweringPassBase<PassImpl> {
 
     Region &constrainFuncBody = constrainFunc.getBody();
 
-    SmallVector<R1CSConstraint, 16> constraints;
-    constrainFuncBody.walk([&constraints, &degreeMemo](EmitEqualityOp eqOp) {
-      constraints.push_back(lowerEquationToR1CS(eqOp.getLhs(), eqOp.getRhs(), degreeMemo));
+    SmallVector<R1CSConstraint> constraints =
+        walkCollectMapped<EmitEqualityOp>(constrainFuncBody, [&degreeMemo](auto eqOp) {
+      return lowerEquationToR1CS(eqOp.getLhs(), eqOp.getRhs(), degreeMemo);
     });
 
     OpBuilder topBuilder(moduleOp.getBodyRegion());

--- a/backends/smt/lib/Conversions/SMTLoweringCommon.cpp
+++ b/backends/smt/lib/Conversions/SMTLoweringCommon.cpp
@@ -17,6 +17,7 @@
 #include "llzk/Dialect/Polymorphic/IR/Ops.h"
 #include "llzk/Dialect/String/IR/Ops.h"
 #include "llzk/Util/TypeHelper.h"
+#include "llzk/Util/Walk.h"
 
 #include <mlir/IR/SymbolTable.h>
 

--- a/backends/smt/lib/Conversions/SMTLoweringCommon.cpp
+++ b/backends/smt/lib/Conversions/SMTLoweringCommon.cpp
@@ -132,11 +132,8 @@ applySMTNoCFBodyConversion(Operation *op, ConversionTarget &target, RewritePatte
     return nullptr;
   }
 
-  SmallVector<component::CreateStructOp> deadStructs;
-  op->walk([&deadStructs](component::CreateStructOp createStructOp) {
-    if (createStructOp->use_empty()) {
-      deadStructs.push_back(createStructOp);
-    }
+  auto deadStructs = walkCollect<component::CreateStructOp>(*op, [](auto createStructOp) {
+    return createStructOp->use_empty();
   });
   for (component::CreateStructOp createStructOp : deadStructs) {
     createStructOp->erase();

--- a/backends/zklean/lib/Target/PrettyPrintZKLean.cpp
+++ b/backends/zklean/lib/Target/PrettyPrintZKLean.cpp
@@ -507,7 +507,6 @@ collectZKLeanStructDefs(ModuleOp module, llvm::DenseSet<StringRef> &structNames)
     if (structNames.insert(name).second) {
       structDefs.push_back(def);
     }
-    return WalkResult::advance();
   });
   return structDefs;
 }

--- a/changelogs/unreleased/th__walk_helpers.yaml
+++ b/changelogs/unreleased/th__walk_helpers.yaml
@@ -1,0 +1,5 @@
+added:
+  - "filtering and mapping `walkCollect` helper functions"
+
+changed:
+  - "renamed `walkContainsMatch` to `walkContains`"

--- a/include/llzk/Dialect/POD/Transforms/TransformationPasses.h
+++ b/include/llzk/Dialect/POD/Transforms/TransformationPasses.h
@@ -46,7 +46,7 @@ inline mlir::Operation *findNearestLoopCarriedPodAccess(ReadPodOp readOp) {
       continue;
     }
 
-    if (walkContainsMatch<WritePodOp>(*parent, [&readOp](WritePodOp writeOp) {
+    if (walkContains<WritePodOp>(*parent, [&readOp](WritePodOp writeOp) {
       return writeOp.getPodRef() == readOp.getPodRef() &&
              writeOp.getRecordNameAttr() == readOp.getRecordNameAttr();
     })) {

--- a/include/llzk/Transforms/SpecializedMemoryPasses.h
+++ b/include/llzk/Transforms/SpecializedMemoryPasses.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include "llzk/Util/Walk.h"
+
 #include <mlir/Analysis/DataLayoutAnalysis.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
 #include <mlir/IR/Builders.h>

--- a/include/llzk/Transforms/SpecializedMemoryPasses.h
+++ b/include/llzk/Transforms/SpecializedMemoryPasses.h
@@ -59,8 +59,9 @@ struct SpecializedSROA : mlir::PassWrapper<SpecializedSROA<AllocOpTy>, mlir::Ope
 
       mlir::OpBuilder builder(&region.front(), region.front().begin());
 
-      mlir::SmallVector<mlir::DestructurableAllocationOpInterface> allocators;
-      region.walk([&allocators](AllocOpTy allocator) { allocators.emplace_back(allocator); });
+      auto allocators = walkCollectMapped<AllocOpTy>(region, [](auto allocator) {
+        return mlir::DestructurableAllocationOpInterface(allocator);
+      });
 
       if (mlir::succeeded(mlir::tryToDestructureMemorySlots(allocators, builder, dataLayout))) {
         changed = true;
@@ -108,8 +109,9 @@ struct SpecializedMem2Reg
 
       mlir::OpBuilder builder(&region.front(), region.front().begin());
 
-      mlir::SmallVector<mlir::PromotableAllocationOpInterface> allocators;
-      region.walk([&allocators](AllocOpTy allocator) { allocators.emplace_back(allocator); });
+      auto allocators = walkCollectMapped<AllocOpTy>(region, [](auto allocator) {
+        return mlir::PromotableAllocationOpInterface(allocator);
+      });
 
       auto promoteRes = mlir::tryToPromoteMemorySlots(allocators, builder, dataLayout, dominance);
       if (mlir::succeeded(promoteRes)) {

--- a/include/llzk/Util/Walk.h
+++ b/include/llzk/Util/Walk.h
@@ -59,7 +59,7 @@ walkCollect(R &root, llvm::function_ref<bool(MatchType)> pred) {
 /// operations in walk order.
 template <typename MatchType, typename R, typename Map>
 inline static auto walkCollectMapped(R &root, Map &&map) {
-  using MappedType = std::invoke_result_t<Map &, MatchType>;
+  using MappedType = std::invoke_result_t<Map &, MatchType &>;
 
   llvm::SmallVector<MappedType> collected;
   root.walk([&collected, &map](MatchType op) { collected.push_back(map(op)); });

--- a/include/llzk/Util/Walk.h
+++ b/include/llzk/Util/Walk.h
@@ -14,18 +14,6 @@
 #include <llvm/ADT/STLFunctionalExtras.h>
 #include <llvm/ADT/SmallVector.h>
 
-/// Returns whether the MLIR walk rooted at `root` contains a `MatchType` instance
-/// satisfying `pred`.
-///
-/// Traversal stops at the first matching instance.
-template <typename MatchType, typename R>
-inline static bool walkContainsMatch(R &root, llvm::function_ref<bool(MatchType)> pred) {
-  return root
-      .walk([&pred](MatchType t) {
-    return pred(t) ? mlir::WalkResult::interrupt() : mlir::WalkResult::advance();
-  }).wasInterrupted();
-}
-
 /// Returns whether the MLIR walk rooted at `root` contains any `MatchType` instance.
 ///
 /// Traversal stops at the first instance of type `MatchType`.
@@ -33,11 +21,47 @@ template <typename MatchType, typename R> inline static bool walkContains(R &roo
   return root.walk([](MatchType) { return mlir::WalkResult::interrupt(); }).wasInterrupted();
 }
 
-/// Collect all walked operations of type `MatchType` rooted at `root` into a
-/// small vector in walk order.
+/// Returns whether the MLIR walk rooted at `root` contains a `MatchType` instance
+/// satisfying `pred`.
+///
+/// Traversal stops at the first matching instance.
+template <typename MatchType, typename R>
+inline static bool walkContains(R &root, llvm::function_ref<bool(MatchType)> pred) {
+  return root
+      .walk([&pred](MatchType t) {
+    return pred(t) ? mlir::WalkResult::interrupt() : mlir::WalkResult::advance();
+  }).wasInterrupted();
+}
+
+/// Walk operations of type `MatchType` from `root` and collect them in walk order.
 template <typename MatchType, typename R>
 inline static llvm::SmallVector<MatchType> walkCollect(R &root) {
   llvm::SmallVector<MatchType> collected;
   root.walk([&collected](MatchType op) { collected.push_back(op); });
+  return collected;
+}
+
+/// Walk operations of type `MatchType` from `root` and collect all operations satisfying `pred` in
+/// walk order.
+template <typename MatchType, typename R>
+inline static llvm::SmallVector<MatchType>
+walkCollect(R &root, llvm::function_ref<bool(MatchType)> pred) {
+  llvm::SmallVector<MatchType> collected;
+  root.walk([&collected, &pred](MatchType op) {
+    if (pred(op)) {
+      collected.push_back(op);
+    }
+  });
+  return collected;
+}
+
+/// Walk operations of type `MatchType` from `root` and collect results of applying `map` to the
+/// operations in walk order.
+template <typename MatchType, typename R, typename Map>
+inline static auto walkCollectMapped(R &root, Map &&map) {
+  using MappedType = std::invoke_result_t<Map &, MatchType>;
+
+  llvm::SmallVector<MappedType> collected;
+  root.walk([&collected, &map](MatchType op) { collected.push_back(map(op)); });
   return collected;
 }

--- a/lib/Dialect/POD/Transforms/PodToScalarPass.cpp
+++ b/lib/Dialect/POD/Transforms/PodToScalarPass.cpp
@@ -270,28 +270,28 @@ inline static bool isSamePodRecord(WritePodOp writeOp, Value podRef, StringAttr 
 
 /// Return whether `op` contains a nested write to `podRef.recordName`.
 static bool hasNestedWriteToRecord(Operation &op, Value podRef, StringAttr recordName) {
-  return walkContainsMatch<WritePodOp>(op, [&](WritePodOp writeOp) {
+  return walkContains<WritePodOp>(op, [&](WritePodOp writeOp) {
     return writeOp.getOperation() != &op && isSamePodRecord(writeOp, podRef, recordName);
   });
 }
 
 /// Return whether `op` contains a nested write to any record of `podRef`.
 static bool hasNestedWriteToPod(Operation &op, Value podRef) {
-  return walkContainsMatch<WritePodOp>(op, [&](WritePodOp writeOp) {
+  return walkContains<WritePodOp>(op, [&](WritePodOp writeOp) {
     return writeOp.getOperation() != &op && writeOp.getPodRef() == podRef;
   });
 }
 
 /// Return whether `op` contains any read from `podRef.recordName`.
 static bool hasReadFromRecord(Operation &op, Value podRef, StringAttr recordName) {
-  return walkContainsMatch<ReadPodOp>(op, [&podRef, &recordName](ReadPodOp readOp) {
+  return walkContains<ReadPodOp>(op, [&podRef, &recordName](ReadPodOp readOp) {
     return isSamePodRecord(readOp, podRef, recordName);
   });
 }
 
 /// Return whether `op` or any nested operation uses `value` as an operand.
 static bool hasValueUse(Operation &op, Value value) {
-  return walkContainsMatch<Operation *>(op, [&value](Operation *nestedOp) {
+  return walkContains<Operation *>(op, [&value](Operation *nestedOp) {
     return llvm::is_contained(nestedOp->getOperands(), value);
   });
 }
@@ -3909,30 +3909,23 @@ public:
 /// reifying the aggregate array-of-POD value or rewriting surrounding function/template
 /// signatures.
 static LogicalResult rejectUnsupportedPodArrayUnifiableCasts(ModuleOp modOp) {
-  WalkResult result = modOp.walk([](UnifiableCastOp op) {
+  auto result = modOp.walk([](UnifiableCastOp op) -> WalkResult {
     ArrayType inputArrTy = splittablePodArray(op.getInput().getType());
     ArrayType resultArrTy = splittablePodArray(op.getType());
     if (!inputArrTy && !resultArrTy) {
       return WalkResult::advance();
     }
     if (!inputArrTy && resultArrTy) {
-      op.emitOpError()
-          .append(
-              "cannot lower a generic input to a split array-of-POD result without rewriting "
-              "the surrounding function/template signature"
-          )
-          .report();
-      return WalkResult::interrupt();
+      return op.emitOpError(
+          "cannot lower a generic input to a split array-of-POD result without rewriting "
+          "the surrounding function/template signature"
+      );
     }
     if (inputArrTy && !resultArrTy) {
-      op.emitOpError()
-          .append(
-              "cannot lower a split array-of-POD input to a non-array result without "
-              "materializing the aggregate or rewriting the surrounding function/template "
-              "signature"
-          )
-          .report();
-      return WalkResult::interrupt();
+      return op.emitOpError(
+          "cannot lower a split array-of-POD input to a non-array result without materializing "
+          "the aggregate or rewriting the surrounding function/template signature"
+      );
     }
     return WalkResult::advance();
   });
@@ -5320,7 +5313,7 @@ void Step3Resolver::configureLateVirtualPodLegality(ConversionTarget &target) co
 }
 
 bool Step3Resolver::hasResolvableLateVirtualPodOps(ModuleOp modOp) const {
-  return walkContainsMatch<Operation *>(*modOp, [this](Operation *op) {
+  return walkContains<Operation *>(*modOp, [this](Operation *op) {
     return TypeSwitch<Operation *, bool>(op)
         .Case<WritePodOp>([this](auto writeOp) {
       return lookupVirtualPodLeafMap(writeOp.getPodRef(), virtualPods) &&
@@ -6375,22 +6368,21 @@ static size_t countResidualPodIR(ModuleOp modOp) {
 
 /// Reject any `array.len` that still targets a tagged ragged nested leaf array.
 static LogicalResult rejectRaggedNestedLeafArrayLengths(ModuleOp modOp) {
-  WalkResult result = modOp.walk([](ArrayLengthOp op) {
+  auto result = modOp.walk([](ArrayLengthOp op) -> WalkResult {
     StringRef raggedKind = getTaggedRaggedNestedLeafKind(op.getArrRef());
     if (raggedKind.empty()) {
       return WalkResult::advance();
     }
-    op.emitOpError() << "cannot lower nested " << raggedKind
-                     << " array leaf length after reading an array-of-POD element without "
-                        "per-element shape witnesses";
-    return WalkResult::interrupt();
+    return op.emitOpError() << "cannot lower nested " << raggedKind
+                            << " array leaf length after reading an array-of-POD element "
+                               "without per-element shape witnesses";
   });
   return failure(result.wasInterrupted());
 }
 
 /// Reject any `constrain.eq` that still compares a tagged ragged nested leaf array.
 static LogicalResult rejectRaggedNestedLeafArrayEqualities(ModuleOp modOp) {
-  WalkResult result = modOp.walk([](constrain::EmitEqualityOp op) {
+  auto result = modOp.walk([](constrain::EmitEqualityOp op) -> WalkResult {
     StringRef raggedKind = getTaggedRaggedNestedLeafKind(op.getLhs());
     if (raggedKind.empty()) {
       raggedKind = getTaggedRaggedNestedLeafKind(op.getRhs());
@@ -6398,60 +6390,55 @@ static LogicalResult rejectRaggedNestedLeafArrayEqualities(ModuleOp modOp) {
     if (raggedKind.empty()) {
       return WalkResult::advance();
     }
-    op.emitOpError() << "cannot lower nested " << raggedKind
-                     << " array leaf equality after reading an array-of-POD element without "
-                        "per-element shape witnesses";
-    return WalkResult::interrupt();
+    return op.emitOpError() << "cannot lower nested " << raggedKind
+                            << " array leaf equality after reading an array-of-POD element "
+                               "without per-element shape witnesses";
   });
   return failure(result.wasInterrupted());
 }
 
 /// Reject any `constrain.in` that still contains a tagged ragged nested leaf array.
 static LogicalResult rejectRaggedNestedLeafArrayContainments(ModuleOp modOp) {
-  WalkResult result = modOp.walk([](constrain::EmitContainmentOp op) {
-    if (succeeded(rejectRaggedNestedLeafContainment(op))) {
-      return WalkResult::advance();
-    }
-    return WalkResult::interrupt();
+  auto result = modOp.walk([](constrain::EmitContainmentOp op) -> WalkResult {
+    return rejectRaggedNestedLeafContainment(op);
   });
   return failure(result.wasInterrupted());
 }
 
 /// Reject tagged ragged nested leaf arrays before function or SCF boundaries strip the tag source.
 static LogicalResult rejectRaggedNestedLeafBoundaryCrossings(ModuleOp modOp) {
-  WalkResult result = modOp.walk([](Operation *op) {
-    LogicalResult check = TypeSwitch<Operation *, LogicalResult>(op)
-                              .Case<CallOp>([](CallOp callOp) {
+  auto result = modOp.walk([](Operation *op) -> WalkResult {
+    return TypeSwitch<Operation *, LogicalResult>(op)
+        .Case<CallOp>([](CallOp callOp) {
       return rejectRaggedNestedLeafBoundaryCrossing(
           callOp.getOperation(), callOp.getArgOperands(), "across a function call"
       );
     })
-                              .Case<ReturnOp>([](ReturnOp returnOp) {
+        .Case<ReturnOp>([](ReturnOp returnOp) {
       return rejectRaggedNestedLeafBoundaryCrossing(
           returnOp.getOperation(), returnOp.getOperands(), "across a function return"
       );
     })
-                              .Case<scf::ForOp>([](scf::ForOp forOp) {
+        .Case<scf::ForOp>([](scf::ForOp forOp) {
       return rejectRaggedNestedLeafBoundaryCrossing(
           forOp.getOperation(), forOp.getInitArgs(), "into an scf.for region"
       );
     })
-                              .Case<scf::WhileOp>([](scf::WhileOp whileOp) {
+        .Case<scf::WhileOp>([](scf::WhileOp whileOp) {
       return rejectRaggedNestedLeafBoundaryCrossing(
           whileOp.getOperation(), whileOp.getInits(), "into an scf.while region"
       );
     })
-                              .Case<scf::ConditionOp>([](scf::ConditionOp conditionOp) {
+        .Case<scf::ConditionOp>([](scf::ConditionOp conditionOp) {
       return rejectRaggedNestedLeafBoundaryCrossing(
           conditionOp.getOperation(), conditionOp.getArgs(), "across an scf.condition boundary"
       );
     })
-                              .Case<scf::YieldOp>([](scf::YieldOp yieldOp) {
+        .Case<scf::YieldOp>([](scf::YieldOp yieldOp) {
       return rejectRaggedNestedLeafBoundaryCrossing(
           yieldOp.getOperation(), yieldOp.getOperands(), "across an scf.yield boundary"
       );
     }).Default([](Operation *) { return success(); });
-    return failed(check) ? WalkResult::interrupt() : WalkResult::advance();
   });
   return failure(result.wasInterrupted());
 }

--- a/lib/Dialect/Polymorphic/Transforms/TypeVarInferencePass.cpp
+++ b/lib/Dialect/Polymorphic/Transforms/TypeVarInferencePass.cpp
@@ -1653,7 +1653,7 @@ static bool funcMentionsParam(FuncDefOp func, StringAttr paramName) {
   if (operationMentionsParam(func.getOperation(), paramName)) {
     return true;
   }
-  return walkContainsMatch<Operation *>(func, [paramName](Operation *op) {
+  return walkContains<Operation *>(func, [paramName](Operation *op) {
     return operationMentionsParam(op, paramName);
   });
 }
@@ -1663,7 +1663,7 @@ static bool contractMentionsParam(verif::ContractOp contract, StringAttr paramNa
   if (operationMentionsParam(contract.getOperation(), paramName)) {
     return true;
   }
-  return walkContainsMatch<Operation *>(contract, [paramName](Operation *op) {
+  return walkContains<Operation *>(contract, [paramName](Operation *op) {
     return operationMentionsParam(op, paramName);
   });
 }
@@ -1680,7 +1680,7 @@ static inline bool targetMentionsParam(verif::ContractOp contract, StringAttr pa
 
 /// Return whether a `poly.expr` body mentions an eligible type-variable parameter.
 static inline bool exprMentionsParam(TemplateExprOp expr, StringAttr paramName) {
-  return walkContainsMatch<Operation *>(expr, [paramName](Operation *op) {
+  return walkContains<Operation *>(expr, [paramName](Operation *op) {
     return operationMentionsParam(op, paramName);
   });
 }
@@ -3823,17 +3823,14 @@ static LogicalResult inferStructTemplateParamUses(
       DenseMap<StringAttr, InferredType> oldTemplateScopeReplacements =
           info.templateScopeReplacements;
       TypeVarInferenceCollector collector(info, info.templateScopeReplacements);
-      WalkResult nonFunctionResult = info.templateOp.walk([&](Operation *op) {
+      auto nonFunctionResult = info.templateOp.walk([&](Operation *op) -> WalkResult {
         if (llvm::isa<FuncDefOp, TemplateExprOp, verif::ContractOp>(op) ||
             hasParentThatIsa<FuncDefOp, TemplateExprOp, verif::ContractOp>(op)) {
           return WalkResult::advance();
         }
-        if (failed(collector.collectOperationStructTemplateParamInferences(
-                op, module, infoByTemplate, tables
-            ))) {
-          return WalkResult::interrupt();
-        }
-        return WalkResult::advance();
+        return collector.collectOperationStructTemplateParamInferences(
+            op, module, infoByTemplate, tables
+        );
       });
       if (nonFunctionResult.wasInterrupted()) {
         return failure();

--- a/lib/Transforms/LLZKRemoveUnusedDiscardableAllocationsPass.cpp
+++ b/lib/Transforms/LLZKRemoveUnusedDiscardableAllocationsPass.cpp
@@ -147,15 +147,15 @@ static FailureOr<bool> removeUnusedDiscardableAllocations(
     SmallVector<Operation *> maybeDeadDefs;
     llvm::SmallPtrSet<Operation *, 16> seen;
 
-    WalkResult walkResult = module->walk([&](Operation *allocator) {
+    auto walkResult = module->walk([&](Operation *allocator) -> WalkResult {
       if (allocator->getName().getStringRef() != allocatorOpName) {
         return WalkResult::advance();
       }
       if (!hasDiscardableAllocationEffect(allocator)) {
-        allocator->emitOpError()
-            << "selected for discardable-allocation cleanup but is not marked with "
-               "MemAlloc<DiscardableAllocationResource>";
-        return WalkResult::interrupt();
+        return allocator->emitOpError(
+            "selected for discardable-allocation cleanup but is not "
+            "marked with MemAlloc<DiscardableAllocationResource>"
+        );
       }
 
       SmallVector<Operation *> usersToErase;

--- a/lib/Transforms/LLZKWhileToForPass.cpp
+++ b/lib/Transforms/LLZKWhileToForPass.cpp
@@ -341,16 +341,13 @@ class PassImpl : public llzk::impl::WhileToForPassBase<PassImpl> {
   void runOnOperation() override {
     Operation *op = getOperation();
     IRRewriter rewriter {op->getContext()};
-    auto result = op->walk([&rewriter](scf::WhileOp loop) {
+    auto result = op->walk([&rewriter](scf::WhileOp loop) -> WalkResult {
       ForOpInfo info = parseInfo(loop);
       if (!info.success()) {
         // Ignore loops we can't prove have constant bounds
         return WalkResult::advance();
       }
-      if (failed(transformWhileToFor(loop, info, rewriter))) {
-        return WalkResult::interrupt();
-      }
-      return WalkResult::advance();
+      return LogicalResult(transformWhileToFor(loop, info, rewriter));
     });
     if (result.wasInterrupted()) {
       signalPassFailure();

--- a/tools/llzk-witgen/WitgenLowering.cpp
+++ b/tools/llzk-witgen/WitgenLowering.cpp
@@ -30,6 +30,7 @@
 #include "llzk/Util/DynamicAPIntHelper.h"
 #include "llzk/Util/Field.h"
 #include "llzk/Util/SymbolHelper.h"
+#include "llzk/Util/Walk.h"
 
 #include <mlir/Conversion/AffineToStandard/AffineToStandard.h>
 #include <mlir/Dialect/Arith/IR/Arith.h>
@@ -2082,15 +2083,10 @@ public:
     }
 
     SymbolTableCollection tables;
-    SmallVector<function::FuncDefOp> funcs;
-    moduleOp.walk([&](function::FuncDefOp funcOp) {
-      if (funcOp.nameIsConstrain()) {
-        return;
-      }
-      funcs.push_back(funcOp);
-    });
-
     BodyLowerer lowerer(moduleOp, tables, field->get(), options);
+    auto funcs = walkCollect<function::FuncDefOp>(moduleOp, [](auto funcOp) {
+      return !funcOp.nameIsConstrain();
+    });
     for (function::FuncDefOp funcOp : funcs) {
       if (failed(lowerer.lowerFunction(funcOp))) {
         signalPassFailure();

--- a/unittests/Analysis/SparseAnalysisTests.cpp
+++ b/unittests/Analysis/SparseAnalysisTests.cpp
@@ -343,8 +343,8 @@ class SparseAnalysisTests : public LLZKTest {};
 
 Operation *findSingleZeroResultFunctionCall(ModuleOp module) {
   Operation *callOp = nullptr;
-  WalkResult walkResult = module.walk([&](Operation *op) {
-    if (!isa<llzk::function::CallOp>(op) || op->getNumResults() != 0) {
+  WalkResult walkResult = module.walk([&](llzk::function::CallOp op) {
+    if (op->getNumResults() != 0) {
       return WalkResult::advance();
     }
     if (callOp != nullptr) {


### PR DESCRIPTION
Added filtering and mapping `walkCollect` helper functions.
Renamed `walkContainsMatch` to `walkContains` (overloaded but not ambiguous).
