### PR TITLE
New verif ops

### DIFF
--- a/changelogs/unreleased/dani__verif-det-extensions.yaml
+++ b/changelogs/unreleased/dani__verif-det-extensions.yaml
@@ -1,3 +1,3 @@
 added:
-  - Operations `verif.det.prove` and `verif.det.assume` for better support determinism checkers.
+  - Operations `verif.det.prove` and `verif.det.assume` to better support determinism checkers.
   - Attribute `function.allow_verif_ops` for the `function.def` op that allows inlining some `verif` dialect ops inside `function.def` ops. 

--- a/changelogs/unreleased/dani__verif-det-extensions.yaml
+++ b/changelogs/unreleased/dani__verif-det-extensions.yaml
@@ -1,0 +1,3 @@
+added:
+  - Operations `verif.det.prove` and `verif.det.assume` for better support determinism checkers.
+  - Attribute `function.allow_verif_ops` for the `function.def` op that allows inlining some `verif` dialect ops inside `function.def` ops. 

--- a/include/llzk/Dialect/Function/IR/Attrs.td
+++ b/include/llzk/Dialect/Function/IR/Attrs.td
@@ -51,8 +51,10 @@ def LLZK_AllowNonNativeFieldOpsAttr
   }];
 }
 
-def LLZK_AllowVerifOpsAttr : FunctionDialectAttr<"AllowVerifOps", "allow_verif_ops"> {
-  let summary = "Marks functions to allow certain `verif` dialect operations within their body";
+def LLZK_AllowVerifOpsAttr
+    : FunctionDialectAttr<"AllowVerifOps", "allow_verif_ops"> {
+  let summary = "Marks functions to allow certain `verif` dialect operations "
+                "within their body";
   let description = [{
     A unit attribute that can be attached to a `FuncDefOp` to indicate that ops 
     marked with `Verification` are allowed within its body.

--- a/include/llzk/Dialect/Function/IR/Attrs.td
+++ b/include/llzk/Dialect/Function/IR/Attrs.td
@@ -51,4 +51,12 @@ def LLZK_AllowNonNativeFieldOpsAttr
   }];
 }
 
+def LLZK_AllowVerifOpsAttr : FunctionDialectAttr<"AllowVerifOps", "allow_verif_ops"> {
+  let summary = "Marks functions to allow certain `verif` dialect operations within their body";
+  let description = [{
+    A unit attribute that can be attached to a `FuncDefOp` to indicate that ops 
+    marked with `Verification` are allowed within its body.
+  }];
+}
+
 #endif // LLZK_FUNCTION_ATTRS

--- a/include/llzk/Dialect/Function/IR/OpTraits.h
+++ b/include/llzk/Dialect/Function/IR/OpTraits.h
@@ -24,7 +24,7 @@ mlir::LogicalResult verifyNotFieldNativeTraitImpl(mlir::Operation *op);
 /// is inside a `function.def` operation.
 ///
 /// For example, `Verification<WitnessGen>` will call this function passing
-/// a callback that runs `WitnessGen::verifyTrait` if the op is inside a 
+/// a callback that runs `WitnessGen::verifyTrait` if the op is inside a
 /// `function.def` operation.
 mlir::LogicalResult
 verifyVerificationTraitImpl(mlir::Operation *op, llvm::function_ref<mlir::LogicalResult()>);

--- a/include/llzk/Dialect/Function/IR/OpTraits.h
+++ b/include/llzk/Dialect/Function/IR/OpTraits.h
@@ -18,6 +18,8 @@ namespace llzk::function {
 mlir::LogicalResult verifyConstraintGenTraitImpl(mlir::Operation *op);
 mlir::LogicalResult verifyWitnessGenTraitImpl(mlir::Operation *op);
 mlir::LogicalResult verifyNotFieldNativeTraitImpl(mlir::Operation *op);
+mlir::LogicalResult
+verifyVerificationTraitImpl(mlir::Operation *op, llvm::function_ref<mlir::LogicalResult()>);
 
 /// Marker for ops that are specific to constraint generation.
 /// Verifies that the surrounding function is marked with the `AllowConstraintAttr`.
@@ -50,6 +52,31 @@ public:
   inline static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
     return verifyNotFieldNativeTraitImpl(op);
   }
+};
+
+/// Marker for ops in the `verif` dialect that can be inlined inside functions.
+template <template <typename T> class... Extra> struct Verification {
+  template <typename TypeClass>
+  // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
+  class Impl : public mlir::OpTrait::TraitBase<TypeClass, Impl> {
+  public:
+    inline static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+      return verifyVerificationTraitImpl(op, [op]() {
+        return mlir::success((mlir::succeeded(Extra<TypeClass>::verifyTrait(op)) && ...));
+      });
+    }
+  };
+};
+
+template <> struct Verification<> {
+  template <typename TypeClass>
+  // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
+  class Impl : public mlir::OpTrait::TraitBase<TypeClass, Impl> {
+  public:
+    inline static mlir::LogicalResult verifyTrait(mlir::Operation *op) {
+      return verifyVerificationTraitImpl(op, nullptr);
+    }
+  };
 };
 
 } // namespace llzk::function

--- a/include/llzk/Dialect/Function/IR/OpTraits.h
+++ b/include/llzk/Dialect/Function/IR/OpTraits.h
@@ -18,6 +18,14 @@ namespace llzk::function {
 mlir::LogicalResult verifyConstraintGenTraitImpl(mlir::Operation *op);
 mlir::LogicalResult verifyWitnessGenTraitImpl(mlir::Operation *op);
 mlir::LogicalResult verifyNotFieldNativeTraitImpl(mlir::Operation *op);
+
+/// Implementation of the `Verification` trait's validation check.
+/// Takes a callback that is used to do additional checks iff the operation
+/// is inside a `function.def` operation.
+///
+/// For example, `Verification<WitnessGen>` will call this function passing
+/// a callback that runs `WitnessGen::verifyTrait` if the op is inside a 
+/// `function.def` operation.
 mlir::LogicalResult
 verifyVerificationTraitImpl(mlir::Operation *op, llvm::function_ref<mlir::LogicalResult()>);
 

--- a/include/llzk/Dialect/Function/IR/OpTraits.td
+++ b/include/llzk/Dialect/Function/IR/OpTraits.td
@@ -33,12 +33,12 @@ def NotFieldNative : NativeOpTrait<"NotFieldNative">, StructuralOpTrait {
 }
 
 /// Marker for ops in the `verif` dialect that can be inlined inside functions.
-/// The op can be marked with additional traits that must be satisfied if the op 
-/// is inlined. The difference between this and passing the attribute as normal 
-/// is that the extra traits are only checked if the op is inlined. This allows 
-/// marking the op with very restrictive traits like `ConstraintGen`. If that trait 
-/// was naively added to the inlinable op it will fail verification when the op 
-/// is not inlined.
+/// The op can be marked with additional traits that must be satisfied if the op
+/// is inlined. The difference between this and passing the attribute as normal
+/// is that the extra traits are only checked if the op is inlined. This allows
+/// marking the op with very restrictive traits like `ConstraintGen`. If that
+/// trait was naively added to the inlinable op it will fail verification when
+/// the op is not inlined.
 ///
 /// For example, an op that can only be inlined inside constrain functions can
 /// be marked with `Verification<["::llzk::function::ConstraintGen"]>`.
@@ -47,7 +47,5 @@ class Verification<list<string> extra = []>
       StructuralOpTrait {
   string cppNamespace = "::llzk::function";
 }
-
-
 
 #endif // LLZK_FUNCTION_TRAITS

--- a/include/llzk/Dialect/Function/IR/OpTraits.td
+++ b/include/llzk/Dialect/Function/IR/OpTraits.td
@@ -32,4 +32,22 @@ def NotFieldNative : NativeOpTrait<"NotFieldNative">, StructuralOpTrait {
   string cppNamespace = "::llzk::function";
 }
 
+/// Marker for ops in the `verif` dialect that can be inlined inside functions.
+/// The op can be marked with additional traits that must be satisfied if the op 
+/// is inlined. The difference between this and passing the attribute as normal 
+/// is that the extra traits are only checked if the op is inlined. This allows 
+/// marking the op with very restrictive traits like `ConstraintGen`. If that trait 
+/// was naively added to the inlinable op it will fail verification when the op 
+/// is not inlined.
+///
+/// For example, an op that can only be inlined inside constrain functions can
+/// be marked with `Verification<["::llzk::function::ConstraintGen"]>`.
+class Verification<list<string> extra = []>
+    : ParamNativeOpTrait<"Verification", !interleave(extra, ",")>,
+      StructuralOpTrait {
+  string cppNamespace = "::llzk::function";
+}
+
+
+
 #endif // LLZK_FUNCTION_TRAITS

--- a/include/llzk/Dialect/Function/IR/Ops.td
+++ b/include/llzk/Dialect/Function/IR/Ops.td
@@ -179,6 +179,14 @@ def FuncDefOp
     /// Add (resp. remove) the `allow_non_native_field_ops` attribute to (resp. from) the function def.
     void setAllowNonNativeFieldOpsAttr(bool newValue = true);
 
+    /// Return `true` iff the function def has the `allow_verif_ops` attribute.
+    inline bool hasAllowVerifOpsAttr() {
+      return getOperation()->hasAttr(llzk::function::AllowVerifOpsAttr::name);
+    }
+
+    /// Add (resp. remove) the `allow_verif_ops` attribute to (resp. from) the function def.
+    void setAllowVerifOpsAttr(bool newValue = true);
+
     /// Return `true` iff the argument at the given index has `pub` attribute.
     bool hasArgPublicAttr(unsigned index);
 

--- a/include/llzk/Dialect/Shared/OpHelpers.h
+++ b/include/llzk/Dialect/Shared/OpHelpers.h
@@ -21,8 +21,10 @@
 #include <mlir/IR/SymbolTable.h>
 #include <mlir/Support/LogicalResult.h>
 
+#include <llvm/ADT/STLExtras.h>
 #include <llvm/ADT/SmallString.h>
 #include <llvm/ADT/StringRef.h>
+#include <llvm/Support/Debug.h>
 
 namespace llzk {
 
@@ -89,34 +91,28 @@ public:
 };
 
 /// See `HasAncestor` ODS documentation for details.
-template <typename... Ancestors> struct HasAncestor {
-  template <typename ConcreteType>
-  static void appendTypeName(mlir::InFlightDiagnostic &diag, bool &first) {
-    if (!first) {
-      diag << ", ";
-    }
-    first = false;
-    diag << '\'' << ConcreteType::getOperationName() << '\'';
-  }
-
+template <typename Ancestor, typename... Ancestors> struct HasAncestor {
   template <typename ConcreteType>
   // Suppress false positive from `clang-tidy`
   // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
   struct Impl : public mlir::OpTrait::TraitBase<ConcreteType, Impl> {
     static mlir::LogicalResult verifyRegionTrait(mlir::Operation *op) {
-      if (hasParentThatIsa<Ancestors...>(op)) {
+      if (hasParentThatIsa<Ancestor, Ancestors...>(op)) {
         return mlir::success();
       }
       auto diag = op->emitOpError();
 
-      if constexpr (sizeof...(Ancestors) == 1) {
-        diag << "must have an ancestor of type ";
+      if constexpr (sizeof...(Ancestors) == 0) {
+        diag << "must have an ancestor of type '" << Ancestor::getOperationName() << '\'';
       } else {
         diag << "must have an ancestor of one of the following types: ";
+        llvm::interleaveComma(
+            llvm::ArrayRef<llvm::StringLiteral>(
+                {Ancestor::getOperationName(), Ancestors::getOperationName()...}
+            ),
+            diag, [&diag](auto name) { diag << '\'' << name << '\''; }
+        );
       }
-
-      bool first = true;
-      (HasAncestor::template appendTypeName<Ancestors>(diag, first), ...);
 
       return diag;
     }

--- a/include/llzk/Dialect/Shared/OpTraits.td
+++ b/include/llzk/Dialect/Shared/OpTraits.td
@@ -39,6 +39,14 @@ class HasAncestor<string op> : ParamNativeOpTrait<"HasAncestor", op>,
   string cppNamespace = "::llzk";
 }
 
+/// Verify that the operation has a parent of one of the `ops` types somewhere in its
+/// ancestry.
+class HasAncestorOf<list<string> ops> : ParamNativeOpTrait<"HasAncestor", !interleave(ops, ", ")>,
+                               StructuralOpTrait {
+  string cppNamespace = "::llzk";
+}
+
+
 // Implements verification for ops with an affine_map instantiation list. These
 // ops are expected to contain the following in their `arguments` list:
 //  - VariadicOfVariadic<Index, "mapOpGroupSizes">:$mapOperands

--- a/include/llzk/Dialect/Shared/OpTraits.td
+++ b/include/llzk/Dialect/Shared/OpTraits.td
@@ -39,13 +39,13 @@ class HasAncestor<string op> : ParamNativeOpTrait<"HasAncestor", op>,
   string cppNamespace = "::llzk";
 }
 
-/// Verify that the operation has a parent of one of the `ops` types somewhere in its
-/// ancestry.
-class HasAncestorOf<list<string> ops> : ParamNativeOpTrait<"HasAncestor", !interleave(ops, ", ")>,
-                               StructuralOpTrait {
+/// Verify that the operation has a parent of one of the `ops` types somewhere
+/// in its ancestry.
+class HasAncestorOf<list<string> ops>
+    : ParamNativeOpTrait<"HasAncestor", !interleave(ops, ", ")>,
+      StructuralOpTrait {
   string cppNamespace = "::llzk";
 }
-
 
 // Implements verification for ops with an affine_map instantiation list. These
 // ops are expected to contain the following in their `arguments` list:

--- a/include/llzk/Dialect/Verif/IR/Ops.td
+++ b/include/llzk/Dialect/Verif/IR/Ops.td
@@ -83,7 +83,7 @@ def VerifSMTProveOp : Op<VerifDialect, "smt_prove", []> {
 // Determinism operations
 //===------------------------------------------------------------------===//
 
-def VerifProveDetOp : VerifDialectOp<"det.prove", [Verification<>]> {
+def ProveDetOp : VerifDialectOp<"det.prove", [Verification<>]> {
   let summary = "proof obligation of determinism";
   let description = [{
     A proof obligation that the operand is deterministic, for a concrete definition
@@ -100,7 +100,7 @@ def VerifProveDetOp : VerifDialectOp<"det.prove", [Verification<>]> {
   let assemblyFormat = "$condition attr-dict `:` type($condition)";
 }
 
-def VerifAssumeDetOp : VerifDialectOp<"det.assume", [Verification<>]> {
+def AssumeDetOp : VerifDialectOp<"det.assume", [Verification<>]> {
   let summary = "hint of determinisms";
   let description = [{
     Hints to the proving backend that the operand is deterministic, for a concrete definition

--- a/include/llzk/Dialect/Verif/IR/Ops.td
+++ b/include/llzk/Dialect/Verif/IR/Ops.td
@@ -173,8 +173,8 @@ def EnsureComputeOp : EnsureOpBase<"compute"> {
 }
 
 def EnsureConstrainOp
-    : EnsureOpBase<"constrain", true,
-                   [Verification<["::llzk::function::ConstraintGen"]>]> {
+    : EnsureOpBase<"constrain",
+                   true, [Verification<["::llzk::function::ConstraintGen"]>]> {
   let summary = "constraint generation postcondition";
 }
 

--- a/include/llzk/Dialect/Verif/IR/Ops.td
+++ b/include/llzk/Dialect/Verif/IR/Ops.td
@@ -18,6 +18,7 @@ include "mlir/Interfaces/FunctionInterfaces.td"
 include "llzk/Dialect/Shared/OpTraits.td"
 include "llzk/Dialect/Shared/Types.td"
 include "llzk/Dialect/Felt/IR/Types.td"
+include "llzk/Dialect/Function/IR/OpTraits.td"
 
 include "mlir/IR/OpAsmInterface.td"
 include "mlir/IR/OpBase.td"
@@ -25,6 +26,9 @@ include "mlir/IR/SymbolInterfaces.td"
 
 class VerifDialectOp<string mnemonic, list<Trait> traits = []>
     : Op<VerifDialect, mnemonic, traits>;
+
+class SideEffectsOp<string mnemonic, list<Trait> traits = []>
+    : VerifDialectOp<mnemonic, traits> {}
 
 class ConditionOp<string mnemonic, list<Trait> traits = []>
     : VerifDialectOp<mnemonic, traits#[ConditionOpInterface]> {
@@ -45,8 +49,13 @@ class ConditionOp<string mnemonic, list<Trait> traits = []>
   }];
 }
 
-class ContractConditionOp<string mnemonic, list<Trait> traits = []>
-    : ConditionOp<mnemonic, traits#[HasAncestor<"::llzk::verif::ContractOp">]>;
+class ContractConditionOp<string mnemonic, bit inlinable = false,
+                          list<Trait> traits = []>
+    : ConditionOp<mnemonic,
+                  traits#!if(inlinable,
+                             [HasAncestorOf<["::llzk::verif::ContractOp",
+                                             "::llzk::function::FuncDefOp"]>],
+                             [HasAncestor<"::llzk::verif::ContractOp">])>;
 
 //===------------------------------------------------------------------===//
 // Struct verification condition operations
@@ -71,13 +80,60 @@ def VerifSMTProveOp : Op<VerifDialect, "smt_prove", []> {
 }
 
 //===------------------------------------------------------------------===//
+// Determinism operations
+//===------------------------------------------------------------------===//
+
+def VerifProveDetOp : VerifDialectOp<"det.prove", [Verification<>]> {
+  let summary = "proof obligation of determinism";
+  let description = [{
+    A proof obligation that the operand is deterministic, for a concrete definition
+    of determinism determined by the backend.
+
+    Returns a boolean that indicates if the operand was proven deterministic or not.
+
+    This operation has the `Verification` trait and can be used inside `function.def` 
+    ops that have the `allow_verif` attribute.
+  }];
+  let arguments = (ins EmitEqType:$condition);
+  let results = (outs I1:$result);
+
+  let assemblyFormat = "$condition attr-dict `:` type($condition)";
+}
+
+def VerifAssumeDetOp : VerifDialectOp<"det.assume", [Verification<>]> {
+  let summary = "hint of determinisms";
+  let description = [{
+    Hints to the proving backend that the operand is deterministic, for a concrete definition
+    of determinism determined by the backend.
+
+    This operation has the `Verification` trait and can be used inside `function.def` 
+    ops that have the `allow_verif` attribute.
+  }];
+  let arguments = (ins EmitEqType:$hint);
+  let results = (outs);
+
+  let assemblyFormat = "$hint attr-dict `:` type($hint)";
+
+  let extraClassDefinition = [{
+    // This side effect models "program termination". Based on
+    // https://github.com/llvm/llvm-project/blob/f325e4b2d836d6e65a4d0cf3efc6b0996ccf3765/mlir/lib/Dialect/ControlFlow/IR/ControlFlowOps.cpp#L92-L97
+    static void getEffects(
+        ::mlir::SmallVectorImpl<::mlir::SideEffects::EffectInstance<::mlir::MemoryEffects::Effect>> &effects
+    ) {
+      effects.emplace_back(::mlir::MemoryEffects::Write::get());
+    }
+  }];
+}
+
+//===------------------------------------------------------------------===//
 // Precondition operations
 //===------------------------------------------------------------------===//
 
 class RequireOpBase<string mnemonic, list<Trait> traits = []>
-    : ContractConditionOp<mnemonic, traits#[PreconditionOpInterface]> {
+    : ContractConditionOp<"require_"#mnemonic, false,
+                          traits#[PreconditionOpInterface]> {
   let description = [{
-    Base of an operation that encodes a precondition.
+    Encodes a precondition in the `@}]#mnemonic#[{` function.
 
     Preconditions:
     - May not depend on values transitively derived from struct member reads
@@ -86,11 +142,11 @@ class RequireOpBase<string mnemonic, list<Trait> traits = []>
   }];
 }
 
-def RequireComputeOp : RequireOpBase<"require_compute"> {
+def RequireComputeOp : RequireOpBase<"compute"> {
   let summary = "witness computation precondition";
 }
 
-def RequireConstrainOp : RequireOpBase<"require_constrain"> {
+def RequireConstrainOp : RequireOpBase<"constrain"> {
   let summary = "constraint generation precondition";
 }
 
@@ -98,14 +154,27 @@ def RequireConstrainOp : RequireOpBase<"require_constrain"> {
 // Postcondition operations
 //===------------------------------------------------------------------===//
 
-class EnsureOpBase<string mnemonic, list<Trait> traits = []>
-    : ContractConditionOp<mnemonic, traits#[PostconditionOpInterface]>;
+class EnsureOpBase<string mnemonic, bit inlinable = false,
+                   list<Trait> traits = []>
+    : ContractConditionOp<"ensure_"#mnemonic, inlinable,
+                          traits#[PostconditionOpInterface]> {
+  let description = [{
+    Encodes a postcondition in the `@}]#mnemonic#[{` function.
+  }]#!if(inlinable, [{
 
-def EnsureComputeOp : EnsureOpBase<"ensure_compute"> {
+    This operation has the `Verification` trait and can be used inside `function.def` 
+    ops that have the `allow_verif` attribute.
+    }],
+         "");
+}
+
+def EnsureComputeOp : EnsureOpBase<"compute"> {
   let summary = "witness computation postcondition";
 }
 
-def EnsureConstrainOp : EnsureOpBase<"ensure_constrain"> {
+def EnsureConstrainOp
+    : EnsureOpBase<"constrain", true,
+                   [Verification<["::llzk::function::ConstraintGen"]>]> {
   let summary = "constraint generation postcondition";
 }
 

--- a/include/llzk/Dialect/Verif/IR/Ops.td
+++ b/include/llzk/Dialect/Verif/IR/Ops.td
@@ -154,16 +154,20 @@ def RequireConstrainOp : RequireOpBase<"constrain"> {
 // Postcondition operations
 //===------------------------------------------------------------------===//
 
+//
 class EnsureOpBase<string mnemonic, bit inlinable = false,
+                   list<string> verificationExtraTraits = [],
                    list<Trait> traits = []>
-    : ContractConditionOp<"ensure_"#mnemonic, inlinable,
-                          traits#[PostconditionOpInterface]> {
+    : ContractConditionOp<
+          "ensure_"#mnemonic, inlinable,
+          traits#[PostconditionOpInterface]#!if(
+              inlinable, [Verification<verificationExtraTraits>], [])> {
   let description = [{
     Encodes a postcondition in the `@}]#mnemonic#[{` function.
   }]#!if(inlinable, [{
 
     This operation has the `Verification` trait and can be used inside `function.def` 
-    ops that have the `allow_verif` attribute.
+    ops that have the `allow_verif_ops` attribute.
     }],
          "");
 }
@@ -173,8 +177,10 @@ def EnsureComputeOp : EnsureOpBase<"compute"> {
 }
 
 def EnsureConstrainOp
-    : EnsureOpBase<"constrain",
-                   true, [Verification<["::llzk::function::ConstraintGen"]>]> {
+    : EnsureOpBase<
+          "constrain",
+          /*inlinable=*/true,
+          /*verificationExtraTraits=*/["::llzk::function::ConstraintGen"]> {
   let summary = "constraint generation postcondition";
 }
 

--- a/lib/Dialect/Function/IR/OpTraits.cpp
+++ b/lib/Dialect/Function/IR/OpTraits.cpp
@@ -15,6 +15,9 @@
 #include "llzk/Dialect/Verif/IR/Ops.h"
 
 #include <mlir/IR/Operation.h>
+#include <mlir/Support/LLVM.h>
+
+#include <llvm/ADT/StringRef.h>
 
 using namespace mlir;
 
@@ -28,6 +31,19 @@ auto parentFuncDefOpHasAttr = [](Operation *op, auto attrFn) -> bool {
   }
   return false;
 };
+
+template <typename Attr, typename F>
+LogicalResult verifyTraitIsPresentInFuncDefOp(Operation *op, F attrFn) {
+  // These are allowed anywhere outside of FuncDefOp but only allowed inside a FuncDefOp
+  // that is marked with the associated attribute.
+  if (FuncDefOp f = op->getParentOfType<FuncDefOp>()) {
+    if (!(f.*attrFn)()) {
+      return op->emitOpError() << "cannot be used within a '" << FuncDefOp::getOperationName()
+                               << "' without the '" << Attr::name << "' attribute";
+    }
+  }
+  return success();
+}
 
 } // namespace
 
@@ -48,15 +64,24 @@ LogicalResult verifyWitnessGenTraitImpl(Operation *op) {
 }
 
 LogicalResult verifyNotFieldNativeTraitImpl(Operation *op) {
-  // These are allowed anywhere outside of FuncDefOp but only allowed inside a FuncDefOp
-  // that is marked with the associated attribute.
+  return verifyTraitIsPresentInFuncDefOp<AllowNonNativeFieldOpsAttr>(
+      op, &FuncDefOp::hasAllowNonNativeFieldOpsAttr
+  );
+}
+
+LogicalResult
+verifyVerificationTraitImpl(Operation *op, llvm::function_ref<LogicalResult()> check) {
+  if (failed(
+          verifyTraitIsPresentInFuncDefOp<AllowVerifOpsAttr>(op, &FuncDefOp::hasAllowVerifOpsAttr)
+      )) {
+    return failure();
+  }
   if (FuncDefOp f = op->getParentOfType<FuncDefOp>()) {
-    if (!f.hasAllowNonNativeFieldOpsAttr()) {
-      return op->emitOpError() << "cannot be used within a '" << FuncDefOp::getOperationName()
-                               << "' without the '" << AllowNonNativeFieldOpsAttr::name
-                               << "' attribute";
+    if (check) {
+      return check();
     }
   }
+
   return success();
 }
 

--- a/lib/Dialect/Function/IR/Ops.cpp
+++ b/lib/Dialect/Function/IR/Ops.cpp
@@ -295,6 +295,14 @@ void FuncDefOp::setAllowNonNativeFieldOpsAttr(bool newValue) {
   }
 }
 
+void FuncDefOp::setAllowVerifOpsAttr(bool newValue) {
+  if (newValue) {
+    getOperation()->setAttr(AllowVerifOpsAttr::name, UnitAttr::get(getContext()));
+  } else {
+    getOperation()->removeAttr(AllowVerifOpsAttr::name);
+  }
+}
+
 bool FuncDefOp::hasArgPublicAttr(unsigned index) {
   if (index < this->getNumArguments()) {
     DictionaryAttr res = function_interface_impl::getArgAttrDict(*this, index);

--- a/test/Dialect/Verif/contracts_pass.llzk
+++ b/test/Dialect/Verif/contracts_pass.llzk
@@ -1,4 +1,4 @@
-// RUN: llzk-opt -split-input-file %s 2>&1 | FileCheck --enable-var-scope %s
+// RUN: llzk-opt -split-input-file -verify-diagnostics %s 2>&1 | FileCheck --enable-var-scope %s
 
 module attributes {llzk.lang} {
   struct.def @Top {
@@ -817,5 +817,33 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:    verif.contract @Wrapper for @wrapper_target (%[[VAL_4:[0-9a-zA-Z_\.]+]]: i1, %[[VAL_5:[0-9a-zA-Z_\.]+]]: i1) {
 // CHECK-NEXT:      verif.include @Leaf(%[[VAL_5]]) : (i1) -> ()
 // CHECK-NEXT:      verif.ensure_compute %[[VAL_5]]
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }
+// -----
+
+module attributes {llzk.main = !struct.type<@Main>, llzk.lang} {
+  struct.def @Main {
+    function.def @compute(%value : !felt.type) -> !struct.type<@Main> {
+      %self = struct.new : !struct.type<@Main>
+      function.return %self : !struct.type<@Main>
+    }
+    function.def @constrain(%self: !struct.type<@Main>, %value : !felt.type) attributes {function.allow_constraint, function.allow_verif_ops} {
+      %ok = arith.constant true
+      verif.ensure_constrain %ok
+      function.return
+    }
+  }
+}
+// CHECK-LABEL: module attributes {llzk.lang, llzk.main = !struct.type<@Main>} {
+// CHECK-NEXT:    struct.def @Main {
+// CHECK-NEXT:      function.def @compute(%[[VAL_0:[0-9a-zA-Z_\.]+]]: !felt.type) -> !struct.type<@Main> attributes {function.allow_witness} {
+// CHECK-NEXT:        %[[VAL_1:[0-9a-zA-Z_\.]+]] = struct.new : <@Main>
+// CHECK-NEXT:        function.return %[[VAL_1]] : !struct.type<@Main>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      function.def @constrain(%[[VAL_2:[0-9a-zA-Z_\.]+]]: !struct.type<@Main>, %[[VAL_3:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_constraint, function.allow_verif_ops} {
+// CHECK-NEXT:        %[[VAL_6:[0-9a-zA-Z_\.]+]] = arith.constant true
+// CHECK-NEXT:        verif.ensure_constrain %[[VAL_6]]
+// CHECK-NEXT:        function.return
+// CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }

--- a/test/Dialect/Verif/det_fail.llzk
+++ b/test/Dialect/Verif/det_fail.llzk
@@ -1,0 +1,16 @@
+// RUN: llzk-opt -split-input-file -verify-diagnostics %s
+
+function.def @det_prove() -> i1  {
+  %c = felt.const 42
+  // expected-error@+1 {{'verif.det.prove' op cannot be used within a 'function.def' without the 'function.allow_verif_ops' attribute}}
+  %d = verif.det.prove %c : !felt.type
+  function.return %d : i1
+}
+
+// -----
+
+function.def @det_assume(%f : !felt.type)  {
+  // expected-error@+1 {{'verif.det.assume' op cannot be used within a 'function.def' without the 'function.allow_verif_ops' attribute}}
+  verif.det.assume %f : !felt.type
+  function.return
+}

--- a/test/Dialect/Verif/det_pass.llzk
+++ b/test/Dialect/Verif/det_pass.llzk
@@ -1,0 +1,24 @@
+// RUN: llzk-opt -split-input-file %s 2>&1 | FileCheck --enable-var-scope %s
+
+
+function.def @det_prove() -> i1 attributes {function.allow_verif_ops} {
+  %c = felt.const 42
+  %d = verif.det.prove %c : !felt.type
+  function.return %d : i1
+}
+//CHECK-LABEL:  function.def @det_prove() -> i1 attributes {function.allow_verif_ops} {
+//CHECK-NEXT:     %[[T1:[0-9a-zA-Z_\.]+]] = felt.const 42
+//CHECK-NEXT:     %[[T2:[0-9a-zA-Z_\.]+]] = verif.det.prove %[[T1]] : !felt.type
+//CHECK-NEXT:     function.return %[[T2]] : i1
+//CHECK-NEXT:   }
+// -----
+
+function.def @det_assume(%f : !felt.type)  attributes {function.allow_verif_ops} {
+  verif.det.assume %f : !felt.type
+  function.return
+}
+//CHECK-LABEL:  function.def @det_assume
+//CHECK-SAME:        (%[[T1:[0-9a-zA-Z_\.]+]]: !felt.type) attributes {function.allow_verif_ops} {
+//CHECK-NEXT:     verif.det.assume %[[T1]] : !felt.type
+//CHECK-NEXT:     function.return 
+//CHECK-NEXT:   }

--- a/test/Dialect/Verif/det_pass.llzk
+++ b/test/Dialect/Verif/det_pass.llzk
@@ -11,6 +11,7 @@ function.def @det_prove() -> i1 attributes {function.allow_verif_ops} {
 //CHECK-NEXT:     %[[T2:[0-9a-zA-Z_\.]+]] = verif.det.prove %[[T1]] : !felt.type
 //CHECK-NEXT:     function.return %[[T2]] : i1
 //CHECK-NEXT:   }
+
 // -----
 
 function.def @det_assume(%f : !felt.type)  attributes {function.allow_verif_ops} {

--- a/unittests/CAPI/Dialect/Verif.cpp
+++ b/unittests/CAPI/Dialect/Verif.cpp
@@ -12,6 +12,7 @@
 #include "../CAPITestBase.h"
 
 #include "llzk-c/Builder.h"
+#include "llzk-c/Dialect/Felt.h"
 
 #include "llzk/Dialect/Bool/IR/Ops.h"
 #include "llzk/Dialect/Cast/IR/Ops.h"
@@ -25,6 +26,7 @@
 
 #include <mlir/CAPI/Wrap.h>
 #include <mlir/Dialect/SCF/IR/SCF.h>
+#include <mlir/IR/BuiltinTypes.h>
 #include <mlir/IR/TypeRange.h>
 #include <mlir/IR/ValueRange.h>
 #include <mlir/Parser/Parser.h>
@@ -34,6 +36,7 @@
 #include <llvm/Support/Debug.h>
 
 #include <cstdint>
+#include <memory>
 
 // Include the auto-generated tests
 #include "llzk/Dialect/Verif/IR/Dialect.capi.test.cpp.inc"
@@ -83,12 +86,19 @@ static mlir::OwningOpRef<mlir::ModuleOp> createModuleWithTargetFunc(
 }
 
 static llzk::verif::ContractOp createCppContract(
-    MlirOpBuilder builder, MlirLocation location, llvm::StringRef name, llvm::StringRef target
+    MlirOpBuilder builder, MlirLocation location, llvm::StringRef name, llvm::StringRef target,
+    mlir::ArrayRef<mlir::Type> inputs, mlir::ArrayRef<mlir::Type> outputs = {}
 ) {
   return unwrap(builder)->create<llzk::verif::ContractOp>(
       unwrap(location), name, mlir::SymbolRefAttr::get(unwrap(builder)->getContext(), target),
-      mlir::FunctionType::get(unwrap(builder)->getContext(), {}, {}), mlir::ArrayAttr()
+      mlir::FunctionType::get(unwrap(builder)->getContext(), inputs, outputs), mlir::ArrayAttr()
   );
+}
+
+static llzk::verif::ContractOp createCppContract(
+    MlirOpBuilder builder, MlirLocation location, llvm::StringRef name, llvm::StringRef target
+) {
+  return createCppContract(builder, location, name, target, {}, {});
 }
 
 static void expectContractHasImplicitTerminator(MlirOperation op) {
@@ -622,6 +632,64 @@ std::unique_ptr<OldOpBuildFuncHelper> OldOpBuildFuncHelper::get() {
       );
       unwrap(builder)->create<llzk::verif::StepYieldOp>(unwrap(location), trueOp);
       return op;
+    }
+  };
+  return std::make_unique<Impl>();
+}
+
+namespace {
+struct VerifDetInnerOpBuildBase {
+  mlir::OwningOpRef<mlir::ModuleOp> parentModule;
+
+  mlir::Value
+  prepareInsertionSite(const CAPITest &testClass, MlirOpBuilder builder, MlirLocation location) {
+    this->parentModule = parseSourceString<mlir::ModuleOp>(
+        R"mlir(
+module attributes {llzk.lang} {
+ function.def @target(%arg: !felt.type) attributes {function.allow_witness} {
+    function.return
+  }
+}
+)mlir",
+        mlir::ParserConfig(unwrap(testClass.context))
+    );
+    unwrap(builder)->setInsertionPointToEnd(parentModule->getBody());
+
+    size_t argCount = 1;
+    llvm::SmallVector<MlirType> argTypes(
+        argCount, llzkFelt_FeltTypeGetUnspecified(testClass.context)
+    );
+    llvm::SmallVector<MlirLocation> argLocs(argCount, location);
+
+    auto contract = createCppContract(
+        builder, location, "ContractUnderTest", "target",
+        {llzk::felt::FeltType::get(unwrap(testClass.context))}
+    );
+    unwrap(builder)->setInsertionPointToStart(&contract.getBody().front());
+
+    return contract.getArgument(0);
+  }
+};
+} // namespace
+
+std::unique_ptr<ProveDetOpBuildFuncHelper> ProveDetOpBuildFuncHelper::get() {
+  struct Impl : public ProveDetOpBuildFuncHelper, VerifDetInnerOpBuildBase {
+    MlirOperation
+    callBuild(const CAPITest &testClass, MlirOpBuilder builder, MlirLocation location) override {
+      auto arg = prepareInsertionSite(testClass, builder, location);
+      return llzkVerif_ProveDetOpBuild(builder, location, wrap(arg));
+    }
+  };
+  return std::make_unique<Impl>();
+}
+
+std::unique_ptr<AssumeDetOpBuildFuncHelper> AssumeDetOpBuildFuncHelper::get() {
+  struct Impl : public AssumeDetOpBuildFuncHelper, VerifDetInnerOpBuildBase {
+
+    MlirOperation
+    callBuild(const CAPITest &testClass, MlirOpBuilder builder, MlirLocation location) override {
+      auto arg = prepareInsertionSite(testClass, builder, location);
+      return llzkVerif_AssumeDetOpBuild(builder, location, wrap(arg));
     }
   };
   return std::make_unique<Impl>();


### PR DESCRIPTION
This PR adds ops to the verif dialect with the idea of lowering them to their corresponding PCL ops. The conversion patterns for that will get added on a separate PR after #691 is merged.


