### PR TITLE
Convert new verif ops to PCL

### DIFF
--- a/backends/pcl/lib/Conversion/PCLLoweringPass/Patterns.cpp
+++ b/backends/pcl/lib/Conversion/PCLLoweringPass/Patterns.cpp
@@ -28,10 +28,12 @@
 #include "llzk/Dialect/Constrain/IR/Ops.h"
 #include "llzk/Dialect/Felt/IR/Ops.h"
 #include "llzk/Dialect/Struct/IR/Ops.h"
+#include "llzk/Dialect/Verif/IR/Ops.h"
 
 #include <mlir/Dialect/Arith/IR/Arith.h>
 #include <mlir/IR/Attributes.h>
 #include <mlir/IR/IRMapping.h>
+#include <mlir/Pass/Pass.h>
 #include <mlir/Support/LLVM.h>
 #include <mlir/Transforms/DialectConversion.h>
 
@@ -48,6 +50,7 @@ using namespace llzk::constrain;
 using namespace llzk::felt;
 using namespace llzk::function;
 using namespace llzk::component;
+using namespace llzk::verif;
 
 namespace {
 
@@ -210,6 +213,20 @@ struct ConvertArithSelectOp : public OpConversionPatternWithTemps<arith::SelectO
     auto conj = rewriter.create<pcl::AndOp>(location, if1, if2);
     rewriter.create<pcl::AssertOp>(location, conj);
 
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// ConvertAssumeDetOp
+//===----------------------------------------------------------------------===//
+
+/// Converts `verif.det.assume` ops into `pcl.assume.deterministic` ops.
+struct ConvertAssumeDetOp : public OpConversionPattern<AssumeDetOp> {
+  using OpConversionPattern<AssumeDetOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(AssumeDetOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const final {
+    rewriter.replaceOpWithNewOp<pcl::AssumeDeterministicOp>(op, adaptor.getHint());
     return success();
   }
 };
@@ -401,6 +418,20 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+// ConvertEnsureConstrainOp
+//===----------------------------------------------------------------------===//
+
+/// Converts `verif.ensure_constrain` ops into `pcl.post_cond` ops.
+struct ConvertEnsureConstrainOp : public OpConversionPattern<EnsureConstrainOp> {
+  using OpConversionPattern<EnsureConstrainOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(EnsureConstrainOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const final {
+    rewriter.replaceOpWithNewOp<pcl::PostOp>(op, adaptor.getCondition());
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // ConvertFreeFunction
 //===----------------------------------------------------------------------===//
 
@@ -532,6 +563,21 @@ struct ConvertNonDetOp : public OpConversionPatternWithTemps<NonDetOp> {
     rewriter.replaceOpWithNewOp<pcl::VarOp>(op, *name, /*public=*/false);
     return success();
   }
+};
+
+//===----------------------------------------------------------------------===//
+// ConvertProveDetOp
+//===----------------------------------------------------------------------===//
+
+/// Converts `verif.det.prove` ops into `pcl.det` ops.
+struct ConvertProveDetOp : public OpConversionPattern<ProveDetOp> {
+  using OpConversionPattern<ProveDetOp>::OpConversionPattern;
+
+  LogicalResult
+    matchAndRewrite(ProveDetOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const final {
+      rewriter.replaceOpWithNewOp<pcl::DetOp>(op, adaptor.getCondition());
+      return success();
+    }
 };
 
 //===----------------------------------------------------------------------===//
@@ -788,6 +834,7 @@ void pcl::lowering::BaseMode::populateStep1ConversionPatterns(
 ) {
   patterns.add<
       // clang-format off
+      ConvertAssumeDetOp,
       ConvertBinaryOp<AddFeltOp, pcl::AddOp>,
       ConvertBinaryOp<AndBoolOp, pcl::AndOp>,
       ConvertBinaryOp<MulFeltOp, pcl::MulOp>,
@@ -799,8 +846,10 @@ void pcl::lowering::BaseMode::populateStep1ConversionPatterns(
       ConvertConstantOp<arith::ConstantOp>,
       ConvertConstrainCall,
       ConvertEmitEqualityOp,
+      ConvertEnsureConstrainOp,
       ConvertFreeFunctionCall,
       ConvertFreeFunctionReturnOp,
+      ConvertProveDetOp,
       ConvertReturnOp,
       ConvertSelfMemberReadOpOfFelt,
       ConvertSelfMemberReadOpOfSubcmp,

--- a/backends/pcl/lib/Conversion/PCLLoweringPass/Patterns.cpp
+++ b/backends/pcl/lib/Conversion/PCLLoweringPass/Patterns.cpp
@@ -225,7 +225,9 @@ struct ConvertArithSelectOp : public OpConversionPatternWithTemps<arith::SelectO
 struct ConvertAssumeDetOp : public OpConversionPattern<AssumeDetOp> {
   using OpConversionPattern<AssumeDetOp>::OpConversionPattern;
 
-  LogicalResult matchAndRewrite(AssumeDetOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const final {
+  LogicalResult matchAndRewrite(
+      AssumeDetOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
+  ) const final {
     rewriter.replaceOpWithNewOp<pcl::AssumeDeterministicOp>(op, adaptor.getHint());
     return success();
   }
@@ -425,7 +427,9 @@ public:
 struct ConvertEnsureConstrainOp : public OpConversionPattern<EnsureConstrainOp> {
   using OpConversionPattern<EnsureConstrainOp>::OpConversionPattern;
 
-  LogicalResult matchAndRewrite(EnsureConstrainOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const final {
+  LogicalResult matchAndRewrite(
+      EnsureConstrainOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
+  ) const final {
     rewriter.replaceOpWithNewOp<pcl::PostOp>(op, adaptor.getCondition());
     return success();
   }
@@ -573,11 +577,12 @@ struct ConvertNonDetOp : public OpConversionPatternWithTemps<NonDetOp> {
 struct ConvertProveDetOp : public OpConversionPattern<ProveDetOp> {
   using OpConversionPattern<ProveDetOp>::OpConversionPattern;
 
-  LogicalResult
-    matchAndRewrite(ProveDetOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter) const final {
-      rewriter.replaceOpWithNewOp<pcl::DetOp>(op, adaptor.getCondition());
-      return success();
-    }
+  LogicalResult matchAndRewrite(
+      ProveDetOp op, OpAdaptor adaptor, ConversionPatternRewriter &rewriter
+  ) const final {
+    rewriter.replaceOpWithNewOp<pcl::DetOp>(op, adaptor.getCondition());
+    return success();
+  }
 };
 
 //===----------------------------------------------------------------------===//

--- a/changelogs/unreleased/dani__verif-det-pcl-conversion.yaml
+++ b/changelogs/unreleased/dani__verif-det-pcl-conversion.yaml
@@ -1,0 +1,2 @@
+added:
+  - Support for converting inlinable `verif` ops into PCL equivalents.

--- a/test/Transforms/PCLLowering/pcl_lowering_pass_small.llzk
+++ b/test/Transforms/PCLLowering/pcl_lowering_pass_small.llzk
@@ -165,3 +165,87 @@ module attributes {llzk.lang} {
 // CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.mul %[[VAL_0]], %[[VAL_0]]
 // CHECK-NEXT:      return %[[VAL_1]] : !pcl.felt
 // CHECK-NEXT:    }
+
+// -----
+
+!F = !felt.type<"koalabear">
+!foo = !struct.type<@det>
+module attributes {llzk.lang} {
+  struct.def @det {
+    struct.member @adv_0_1: !F 
+    function.def @compute() -> !foo {
+      %self = struct.new : !foo 
+      function.return %self : !foo
+    }
+    function.def @constrain(%self: !foo) attributes {function.allow_constrain, function.allow_verif_ops} {
+      %0 = struct.readm %self[@adv_0_1] : !foo, !F 
+      %1 = verif.det.prove %0 : !F
+      %c1 = felt.const 1 : !F 
+      %2 = cast.tofelt %1 : i1, !F 
+      constrain.eq %2, %c1 : !F, !F
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   func.func @det() {
+// CHECK-NEXT:      %[[VAL_0:[0-9a-zA-Z_\.]+]] = pcl.var "adv_0_1" false 
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.det %[[VAL_0]]
+// CHECK-NEXT:      %[[VAL_2:[0-9a-zA-Z_\.]+]] = pcl.asfelt %[[VAL_1]]
+// CHECK-NEXT:      %[[VAL_3:[0-9a-zA-Z_\.]+]] = pcl.const 1
+// CHECK-NEXT:      %[[VAL_4:[0-9a-zA-Z_\.]+]] = pcl.eq %[[VAL_2]], %[[VAL_3]]
+// CHECK-NEXT:      pcl.assert %[[VAL_4]]
+// CHECK-NEXT:      return 
+// CHECK-NEXT:    }
+
+// -----
+
+!F = !felt.type<"koalabear">
+!foo = !struct.type<@assume_det>
+module attributes {llzk.lang} {
+  struct.def @assume_det {
+    struct.member @adv_0_1: !F 
+    function.def @compute() -> !foo {
+      %self = struct.new : !foo 
+      function.return %self : !foo
+    }
+    function.def @constrain(%self: !foo) attributes {function.allow_constrain, function.allow_verif_ops} {
+      %0 = struct.readm %self[@adv_0_1] : !foo, !F 
+      verif.det.assume %0 : !F
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   func.func @assume_det() {
+// CHECK-NEXT:      %[[VAL_0:[0-9a-zA-Z_\.]+]] = pcl.var "adv_0_1" false 
+// CHECK-NEXT:      pcl.assume.deterministic %[[VAL_0]]
+// CHECK-NEXT:      return 
+// CHECK-NEXT:    }
+
+// -----
+
+!F = !felt.type<"koalabear">
+!foo = !struct.type<@post_cond>
+module attributes {llzk.lang} {
+  struct.def @post_cond {
+    struct.member @adv_0_1: !F 
+    function.def @compute() -> !foo {
+      %self = struct.new : !foo 
+      function.return %self : !foo
+    }
+    function.def @constrain(%self: !foo) attributes {function.allow_constrain, function.allow_verif_ops} {
+      %0 = struct.readm %self[@adv_0_1] : !foo, !F 
+      %1 = verif.det.prove %0 : !F
+      verif.ensure_constrain %1
+      function.return
+    }
+  }
+}
+
+// CHECK-LABEL:   func.func @post_cond() {
+// CHECK-NEXT:      %[[VAL_0:[0-9a-zA-Z_\.]+]] = pcl.var "adv_0_1" false 
+// CHECK-NEXT:      %[[VAL_1:[0-9a-zA-Z_\.]+]] = pcl.det %[[VAL_0]]
+// CHECK-NEXT:      pcl.post_cond %[[VAL_1]]
+// CHECK-NEXT:      return 
+// CHECK-NEXT:    }


### PR DESCRIPTION
Adds support in `--llzk-to-pcl` for converting the latest `verif` dialect ops to PCL.
