### PR TITLE
Make `StructDefOp::getType` always produce param list for structs in a template

### DIFF
--- a/lib/Dialect/Struct/IR/Ops.cpp
+++ b/lib/Dialect/Struct/IR/Ops.cpp
@@ -172,12 +172,10 @@ StructType StructDefOp::getType(std::optional<ArrayAttr> constParams) {
   }
   // Check if there is an enclosing `TemplateOp` defining parameters, else there are none.
   if (TemplateOp parent = getParentOfType<TemplateOp>(*this)) {
-    auto params = parent.getConstNames<TemplateParamOp>();
-    if (!params.empty()) {
-      return StructType::get(pathRes.value(), params);
-    }
+    return StructType::get(pathRes.value(), parent.getConstNames<TemplateParamOp>());
+  } else {
+    return StructType::get(pathRes.value());
   }
-  return StructType::get(pathRes.value());
 }
 
 std::string StructDefOp::getHeaderString() {


### PR DESCRIPTION
`StructDefOp::getType` should always produce a param list for structs within a template, even if that list is empty because there are no params.
This PR reverts an [unnecessary change](https://github.com/project-llzk/llzk-lib/pull/609/changes/7ea078671720edf2d0d4b7010daa83d92fd8683f#diff-ff7b900fbd54d0dd611cc0df861b28e8d873e6516d2216fd8e0fb9ac887d786e).