### PR TITLE
Disallow wildcard as struct parameter

### DIFF
--- a/changelogs/unreleased/th__struct_type_wildcard_restriction.yaml
+++ b/changelogs/unreleased/th__struct_type_wildcard_restriction.yaml
@@ -1,0 +1,2 @@
+changed:
+  - Disallow wildcard '?' as struct type parameter

--- a/include/llzk/Dialect/Struct/IR/Types.td
+++ b/include/llzk/Dialect/Struct/IR/Types.td
@@ -30,7 +30,8 @@ def LLZK_StructType : StructDialectType<"Struct", "type"> {
     Type of a `struct` op instance. For structs that contain template parameters,
     the type must contain a list of attributes that instantiate the template
     parameters, one per parameter. Each attribute must be one of the following:
-      - IntegerAttr (with IndexType), specifying a fixed parameter value
+      - IntegerAttr (with IndexType), specifying a fixed parameter value; the
+        wildcard (`?`) is not allowed
       - SymbolRefAttr, specifying a parameter value defined by a struct parameter
         or global constant
       - AffineMapAttr, for an array of struct elements whose template parameters

--- a/lib/Util/TypeHelper.cpp
+++ b/lib/Util/TypeHelper.cpp
@@ -444,6 +444,11 @@ public:
       if (!StructParamTypes::matches(p)) {
         StructParamTypes::reportInvalid(emitError, p, "Struct parameter");
         success = false;
+      } else if (IntegerAttr i = llvm::dyn_cast<IntegerAttr>(p); i && isDynamic(i)) {
+        if (emitError) {
+          emitError().append("wildcard '?' is not allowed as struct type parameter").report();
+        }
+        success = false;
       } else if (TypeAttr tyAttr = llvm::dyn_cast<TypeAttr>(p)) {
         if (!isValidTypeImpl(tyAttr.getValue())) {
           if (emitError) {

--- a/test/Dialect/Struct/types_fail.llzk
+++ b/test/Dialect/Struct/types_fail.llzk
@@ -13,3 +13,22 @@ module attributes {llzk.lang} {
     }
   }
 }
+
+// -----
+
+module attributes {llzk.lang} {
+  poly.template @T {
+    poly.param @N : index
+
+    struct.def @Generic {
+      function.def @compute() -> !struct.type<@T::@Generic<[@N]>> {
+        %self = struct.new : !struct.type<@T::@Generic<[@N]>>
+        function.return %self : !struct.type<@T::@Generic<[@N]>>
+      }
+      function.def @constrain(%self: !struct.type<@T::@Generic<[@N]>>) { function.return }
+    }
+  }
+
+  // expected-error@+1 {{wildcard '?' is not allowed as struct type parameter}}
+  function.def private @takes_wildcard_param(!struct.type<@T::@Generic<[?]>>)
+}

--- a/unittests/Util/TypeHelperTest.cpp
+++ b/unittests/Util/TypeHelperTest.cpp
@@ -47,13 +47,14 @@ TEST_F(TypeHelperTests, test_arrayTypesUnify_withDynamic_2) {
 }
 
 TEST_F(TypeHelperTests, test_structTypesUnify) {
+  // StructType itself cannot be created with `?` in its parameter list.
+  // Instead test a nested ArrayType as TypeAttr in the list passes.
   IndexType tyIndex = IndexType::get(&ctx);
-  Attribute i1 = IntegerAttr::get(tyIndex, 128);
-  Attribute i2 = IntegerAttr::get(tyIndex, ShapedType::kDynamic);
-  StructType a = StructType::get(FlatSymbolRefAttr::get(&ctx, "TheName"), ArrayRef {i1});
-  StructType b = StructType::get(FlatSymbolRefAttr::get(&ctx, "TheName"), ArrayRef {i2});
-  // `false` because StructType does not allow `kDynamic`
-  ASSERT_FALSE(structTypesUnify(a, b));
+  Attribute t1 = TypeAttr::get(ArrayType::get(tyIndex, {242, ShapedType::kDynamic}));
+  Attribute t2 = TypeAttr::get(ArrayType::get(tyIndex, {ShapedType::kDynamic, 5}));
+  StructType a = StructType::get(FlatSymbolRefAttr::get(&ctx, "TheName"), ArrayRef {t1});
+  StructType b = StructType::get(FlatSymbolRefAttr::get(&ctx, "TheName"), ArrayRef {t2});
+  ASSERT_TRUE(structTypesUnify(a, b));
 }
 
 TEST_F(TypeHelperTests, test_podTypesUnify_Pass) {

--- a/unittests/Util/TypeHelperTest.cpp
+++ b/unittests/Util/TypeHelperTest.cpp
@@ -48,7 +48,7 @@ TEST_F(TypeHelperTests, test_arrayTypesUnify_withDynamic_2) {
 
 TEST_F(TypeHelperTests, test_structTypesUnify) {
   // StructType itself cannot be created with `?` in its parameter list.
-  // Instead test a nested ArrayType as TypeAttr in the list passes.
+  // Instead, test that a nested ArrayType as a TypeAttr in the list passes.
   IndexType tyIndex = IndexType::get(&ctx);
   Attribute t1 = TypeAttr::get(ArrayType::get(tyIndex, {242, ShapedType::kDynamic}));
   Attribute t2 = TypeAttr::get(ArrayType::get(tyIndex, {ShapedType::kDynamic, 5}));


### PR DESCRIPTION
This restriction should have been added originally when wildcard support was added. There is no reason to use the `?` in that position.