### PR TITLE
Treat `?` wildcard as less concrete in `isMoreConcreteUnification`

### DIFF
--- a/changelogs/unreleased/th__fix_is_more_concrete.yaml
+++ b/changelogs/unreleased/th__fix_is_more_concrete.yaml
@@ -1,0 +1,2 @@
+changed:
+  - "`isMoreConcreteUnification` now treats wildcard dimensions as less concrete than statically-known dimensions"

--- a/include/llzk/Util/TypeHelper.h
+++ b/include/llzk/Util/TypeHelper.h
@@ -291,8 +291,9 @@ inline bool singletonTypeListsUnify(
 ///
 /// The types `i1`, `index`, `felt.type`, and `string.type` are concrete whereas `poly.tvar` is
 /// not (because it may be substituted with any type during struct instantiation). When considering
-/// the attributes with `array.type` and `struct.type` types, we define IntegerAttr and TypeAttr
-/// as concrete, AffineMapAttr as less concrete than those, and SymbolRefAttr as least concrete.
+/// the attributes within `array.type` and `struct.type` types, we define IntegerAttr and TypeAttr
+/// as concrete then (in decreasing order) AffineMapAttr, SymbolRefAttr, and finally the wildcard
+/// (i.e. `?`) attribute as least concrete.
 bool isMoreConcreteUnification(
     mlir::Type oldTy, mlir::Type newTy,
     llvm::function_ref<bool(mlir::Type oldTy, mlir::Type newTy)> knownOldToNew = nullptr

--- a/lib/Util/TypeHelper.cpp
+++ b/lib/Util/TypeHelper.cpp
@@ -611,16 +611,22 @@ struct UnifierImpl {
   ArrayRef<StringRef> rhsRevPrefix;
   UnificationMap *unifications;
   AffineInstantiations *affineToIntTracker;
+  bool *staticLhsWithWildcardRhsTracker;
   // This optional function can be used to provide an exception to the standard unification
   // rules and return a true/success result when it otherwise may not.
   llvm::function_ref<bool(Type oldTy, Type newTy)> overrideSuccess;
 
   UnifierImpl(UnificationMap *unificationMap, ArrayRef<StringRef> rhsReversePrefix = {})
       : rhsRevPrefix(rhsReversePrefix), unifications(unificationMap), affineToIntTracker(nullptr),
-        overrideSuccess(nullptr) {}
+        staticLhsWithWildcardRhsTracker(nullptr), overrideSuccess(nullptr) {}
 
   UnifierImpl &trackAffineToInt(AffineInstantiations *tracker) {
     this->affineToIntTracker = tracker;
+    return *this;
+  }
+
+  UnifierImpl &trackStaticLhsWithWildcardRhs(bool *tracker) {
+    this->staticLhsWithWildcardRhsTracker = tracker;
     return *this;
   }
 
@@ -869,6 +875,9 @@ private:
       }
       if (IntegerAttr rhsIntAttr = dyn_cast_if_dynamic(rhsAttr)) {
         if (is_const_like(lhsAttr)) {
+          if (staticLhsWithWildcardRhsTracker) {
+            *staticLhsWithWildcardRhsTracker = true;
+          }
           return true;
         }
       }
@@ -938,19 +947,26 @@ bool isMoreConcreteUnification(
 ) {
   UnificationMap unifications;
   AffineInstantiations affineInstantiations;
+  bool staticLhsBecomesWildcardRhs = false;
   // Run type unification with the addition that affine map can become integer in the new type.
   if (!UnifierImpl(&unifications)
            .trackAffineToInt(&affineInstantiations)
+           .trackStaticLhsWithWildcardRhs(&staticLhsBecomesWildcardRhs)
            .withOverrides(knownOldToNew)
            .typesUnify(oldTy, newTy)) {
     return false;
   }
 
-  // If either map contains RHS-keyed mappings then the old type is "more concrete" than the new.
-  // In the UnificationMap, a RHS key would indicate that the new type contains a SymbolRef (i.e.
-  // the "least concrete" attribute kind) where the old type contained any other attribute. In the
-  // AffineInstantiations map, a RHS key would indicate that the new type contains an AffineMapAttr
-  // where the old type contains an IntegerAttr.
+  // If a statically-known LHS value becomes a wildcard in the RHS, it is not more concrete.
+  if (staticLhsBecomesWildcardRhs) {
+    return false;
+  }
+
+  // If either map contains RHS-keyed mappings then the old type is more concrete than the new. In
+  // the UnificationMap, a RHS key would indicate that the new type contains a SymbolRef (i.e. the
+  // second-least concrete attribute kind, only to wildcard which was checked above) where the old
+  // type contained some other attribute. In the AffineInstantiations map, a RHS key would indicate
+  // that the new type contains an AffineMapAttr where the old type contains an IntegerAttr.
   auto entryIsRHS = [](const auto &entry) { return entry.first.second == Side::RHS; };
   return !llvm::any_of(unifications, entryIsRHS) && !llvm::any_of(affineInstantiations, entryIsRHS);
 }

--- a/lib/Util/TypeHelper.cpp
+++ b/lib/Util/TypeHelper.cpp
@@ -841,16 +841,6 @@ private:
         }
       }
     }
-    // If either side is a SymbolRefAttr, assume they unify because either flattening or a pass with
-    // a more involved value analysis is required to check if they are actually the same value.
-    if (SymbolRefAttr lhsSymRef = llvm::dyn_cast<SymbolRefAttr>(lhsAttr)) {
-      track(Side::LHS, lhsSymRef, rhsAttr);
-      return true;
-    }
-    if (SymbolRefAttr rhsSymRef = llvm::dyn_cast<SymbolRefAttr>(rhsAttr)) {
-      track(Side::RHS, rhsSymRef, lhsAttr);
-      return true;
-    }
     // If either side is ShapedType::kDynamic then, similarly to Symbols, assume they unify.
     // NOTE: Dynamic array dimensions (i.e. '?') are allowed in LLZK but should generally be
     // restricted to scenarios where it can be replaced with a concrete value during the flattening
@@ -881,6 +871,16 @@ private:
           return true;
         }
       }
+    }
+    // If either side is a SymbolRefAttr, assume they unify because either flattening or a pass with
+    // a more involved value analysis is required to check if they are actually the same value.
+    if (SymbolRefAttr lhsSymRef = llvm::dyn_cast<SymbolRefAttr>(lhsAttr)) {
+      track(Side::LHS, lhsSymRef, rhsAttr);
+      return true;
+    }
+    if (SymbolRefAttr rhsSymRef = llvm::dyn_cast<SymbolRefAttr>(rhsAttr)) {
+      track(Side::RHS, rhsSymRef, lhsAttr);
+      return true;
     }
     // If both are type refs, check for unification of the types.
     if (TypeAttr lhsTy = llvm::dyn_cast<TypeAttr>(lhsAttr)) {

--- a/unittests/Util/TypeHelperTest.cpp
+++ b/unittests/Util/TypeHelperTest.cpp
@@ -54,7 +54,7 @@ TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardDimension) {
 
   ASSERT_TRUE(typesUnify(wildcardArray, staticArray));
   ASSERT_TRUE(isMoreConcreteUnification(wildcardArray, staticArray));
-  ASSERT_TRUE(isMoreConcreteUnification(staticArray, wildcardArray));
+  ASSERT_FALSE(isMoreConcreteUnification(staticArray, wildcardArray));
 }
 
 TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardDimension3) {
@@ -64,7 +64,7 @@ TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardDimension3) 
 
   ASSERT_TRUE(typesUnify(wildcardArray, staticArray));
   ASSERT_TRUE(isMoreConcreteUnification(wildcardArray, staticArray));
-  ASSERT_TRUE(isMoreConcreteUnification(staticArray, wildcardArray));
+  ASSERT_FALSE(isMoreConcreteUnification(staticArray, wildcardArray));
 }
 
 TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardDimensionsMix) {
@@ -73,8 +73,8 @@ TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardDimensionsMi
   ArrayType secondArray = ArrayType::get(feltTy, {2, ShapedType::kDynamic});
 
   ASSERT_TRUE(typesUnify(firstArray, secondArray));
-  ASSERT_TRUE(isMoreConcreteUnification(firstArray, secondArray));
-  ASSERT_TRUE(isMoreConcreteUnification(secondArray, firstArray));
+  ASSERT_FALSE(isMoreConcreteUnification(firstArray, secondArray));
+  ASSERT_FALSE(isMoreConcreteUnification(secondArray, firstArray));
 }
 
 TEST_F(TypeHelperTests, test_structTypesUnify) {

--- a/unittests/Util/TypeHelperTest.cpp
+++ b/unittests/Util/TypeHelperTest.cpp
@@ -77,6 +77,27 @@ TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardDimensionsMi
   ASSERT_FALSE(isMoreConcreteUnification(secondArray, firstArray));
 }
 
+TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardAndSymbolRefDimension) {
+  felt::FeltType feltTy = felt::FeltType::get(&ctx);
+  ArrayType wildcardArray = ArrayType::get(feltTy, {ShapedType::kDynamic});
+  ArrayType symbolRefArray = ArrayType::get(feltTy, {FlatSymbolRefAttr::get(&ctx, "N")});
+
+  ASSERT_TRUE(typesUnify(wildcardArray, symbolRefArray));
+  ASSERT_TRUE(isMoreConcreteUnification(wildcardArray, symbolRefArray));
+  ASSERT_FALSE(isMoreConcreteUnification(symbolRefArray, wildcardArray));
+}
+
+TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardAndAffineMapDimension) {
+  felt::FeltType feltTy = felt::FeltType::get(&ctx);
+  ArrayType wildcardArray = ArrayType::get(feltTy, {ShapedType::kDynamic});
+  auto aff = AffineMapAttr::get(OpBuilder(&ctx).getDimIdentityMap());
+  ArrayType affineMapArray = ArrayType::get(feltTy, {aff});
+
+  ASSERT_TRUE(typesUnify(wildcardArray, affineMapArray));
+  ASSERT_TRUE(isMoreConcreteUnification(wildcardArray, affineMapArray));
+  ASSERT_FALSE(isMoreConcreteUnification(affineMapArray, wildcardArray));
+}
+
 TEST_F(TypeHelperTests, test_structTypesUnify) {
   // StructType itself cannot be created with `?` in its parameter list.
   // Instead, test that a nested ArrayType as a TypeAttr in the list passes.

--- a/unittests/Util/TypeHelperTest.cpp
+++ b/unittests/Util/TypeHelperTest.cpp
@@ -12,6 +12,7 @@
 #include "../LLZKTestBase.h"
 
 #include "llzk/Dialect/Array/IR/Types.h"
+#include "llzk/Dialect/Felt/IR/Types.h"
 #include "llzk/Dialect/POD/IR/Types.h"
 #include "llzk/Dialect/Struct/IR/Types.h"
 
@@ -32,18 +33,48 @@ protected:
   OwningEmitErrorFn errFn;
 };
 
-TEST_F(TypeHelperTests, test_arrayTypesUnify_withDynamic_1) {
+TEST_F(TypeHelperTests, test_arrayTypesUnify_withWildcard_1) {
   IndexType tyIndex = IndexType::get(&ctx);
   ArrayType a = ArrayType::get(tyIndex, {2, ShapedType::kDynamic});
   ArrayType b = ArrayType::get(tyIndex, {2, 5});
   ASSERT_TRUE(arrayTypesUnify(a, b));
 }
 
-TEST_F(TypeHelperTests, test_arrayTypesUnify_withDynamic_2) {
+TEST_F(TypeHelperTests, test_arrayTypesUnify_withWildcard_2) {
   IndexType tyIndex = IndexType::get(&ctx);
   ArrayType a = ArrayType::get(tyIndex, {2, ShapedType::kDynamic});
   ArrayType b = ArrayType::get(tyIndex, {ShapedType::kDynamic, 5});
   ASSERT_TRUE(arrayTypesUnify(a, b));
+}
+
+TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardDimension) {
+  felt::FeltType feltTy = felt::FeltType::get(&ctx);
+  ArrayType wildcardArray = ArrayType::get(feltTy, {ShapedType::kDynamic});
+  ArrayType staticArray = ArrayType::get(feltTy, {1});
+
+  ASSERT_TRUE(typesUnify(wildcardArray, staticArray));
+  ASSERT_TRUE(isMoreConcreteUnification(wildcardArray, staticArray));
+  ASSERT_TRUE(isMoreConcreteUnification(staticArray, wildcardArray));
+}
+
+TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardDimension3) {
+  felt::FeltType feltTy = felt::FeltType::get(&ctx);
+  ArrayType wildcardArray = ArrayType::get(feltTy, {4, 5, ShapedType::kDynamic});
+  ArrayType staticArray = ArrayType::get(feltTy, {4, 5, 6});
+
+  ASSERT_TRUE(typesUnify(wildcardArray, staticArray));
+  ASSERT_TRUE(isMoreConcreteUnification(wildcardArray, staticArray));
+  ASSERT_TRUE(isMoreConcreteUnification(staticArray, wildcardArray));
+}
+
+TEST_F(TypeHelperTests, test_isMoreConcreteUnification_arrayWildcardDimensionsMix) {
+  felt::FeltType feltTy = felt::FeltType::get(&ctx);
+  ArrayType firstArray = ArrayType::get(feltTy, {ShapedType::kDynamic, 2});
+  ArrayType secondArray = ArrayType::get(feltTy, {2, ShapedType::kDynamic});
+
+  ASSERT_TRUE(typesUnify(firstArray, secondArray));
+  ASSERT_TRUE(isMoreConcreteUnification(firstArray, secondArray));
+  ASSERT_TRUE(isMoreConcreteUnification(secondArray, firstArray));
 }
 
 TEST_F(TypeHelperTests, test_structTypesUnify) {


### PR DESCRIPTION
Previously `isMoreConcreteUnification` returned true for both directions:
- !array.type<? x felt> → !array.type<1 x felt>
- !array.type<1 x felt> → !array.type<? x felt>